### PR TITLE
fix(pulumi): use empty apiGroup for PVC clone dataSource (core group, not "v1")

### DIFF
--- a/packages/pulumi/src/postgres.ts
+++ b/packages/pulumi/src/postgres.ts
@@ -102,7 +102,7 @@ export class PostgresCluster extends pulumi.ComponentResource {
                         pvcTemplate: this.args.fromPVC
                             ? {
                                   dataSource: {
-                                      apiGroup: 'v1',
+                                      apiGroup: '',
                                       name: this.args.fromPVC,
                                       kind: 'PersistentVolumeClaim',
                                   },


### PR DESCRIPTION
## Summary

`PostgresCluster` sets `pvcTemplate.dataSource.apiGroup: 'v1'` when restoring from an existing PVC (the `<app>:fromVolume` flow in `databases.ts`).

## Root cause

`PersistentVolumeClaim` is a core-group kind, so `apiGroup` must be `''` (empty string) — `"v1"` is the API *version*, not a group. The apiserver rejects the `dataSource` (or silently drops it per the documented "disallowed values are ignored" behavior), so the restore creates an empty PVC instead of a clone of the source volume.

## Fix

Set `apiGroup: ''` in the `dataSource`.

## Verification

- `npm run build` (library `tsc`) — clean
- `tsc --noEmit` and `eslint .` — clean

