### PR TITLE
fix(pulumi): fix node affinity example to use = separator matching the parser

### DIFF
--- a/packages/pulumi/src/nodes.ts
+++ b/packages/pulumi/src/nodes.ts
@@ -112,7 +112,7 @@ export class Nodes {
      * Format: key=value1|value2|value3
      *
      * Examples:
-     * - "topology.kubernetes.io/zone: zone1|zone2" - matches nodes with label set to either "zone1" or "zone2"
+     * - "topology.kubernetes.io/zone=zone1|zone2" - matches nodes with label set to either "zone1" or "zone2"
      * - "orangelab/gpu-nvidia" - matches nodes that have the label (any value)
      *
      * @param labelSpec - Label specification in format "key", "key=value" or "key=value1|value2"


### PR DESCRIPTION
## Summary

The doc comment example in `nodes.ts` for `getNodeSelectorTerm()` shows `"topology.kubernetes.io/zone: zone1|zone2"`.

## Root cause

The parser splits on `'='` and the documented format is `key=value1|value2`. A user following the example would get a single label key of `topology.kubernetes.io/zone: zone1|zone2` (an `Exists` match on a nonsense key) instead of the intended zone affinity.

## Fix

Change the example to `"topology.kubernetes.io/zone=zone1|zone2"`.

## Verification

- `tsc --noEmit` and `eslint .` — clean (comment-only change)

