### PR TITLE
fix(bitcoin): inline rpcauth lines for Bitcoin Core since rpcauthfile is Knots-only

### DIFF
--- a/stacks/bitcoin/components/bitcoin-core/bitcoin-core.ts
+++ b/stacks/bitcoin/components/bitcoin-core/bitcoin-core.ts
@@ -34,8 +34,9 @@ export class BitcoinCore extends pulumi.ComponentResource {
                     debugExclude,
                     externalIp,
                     maxConnections,
+                    rpcUsers: this.args.rpcUsers,
+                    useRpcAuthFile: false,
                 }),
-                'rpc.conf': BitcoinConf.createRpc(this.args.rpcUsers),
             },
         });
 
@@ -61,7 +62,7 @@ export class BitcoinCore extends pulumi.ComponentResource {
                 { name: 'p2p', port: 8333, protocol: 'tcp' },
             ],
             command: command ? command.split(' ') : undefined,
-            commandArgs: commandArgs.split(' '),
+            commandArgs: commandArgs.split(' ').filter(Boolean),
             initContainers: [
                 {
                     name: 'copy-config',
@@ -78,10 +79,7 @@ export class BitcoinCore extends pulumi.ComponentResource {
             ],
             runAsUser,
             volumeOwnerUserId,
-            volumeMounts: [
-                { mountPath: volumePath },
-                { name: 'config', mountPath: '/conf', readOnly: true },
-            ],
+            volumeMounts: [{ mountPath: volumePath }],
         });
     }
 }

--- a/stacks/bitcoin/components/bitcoin-knots/bitcoin-knots.ts
+++ b/stacks/bitcoin/components/bitcoin-knots/bitcoin-knots.ts
@@ -33,8 +33,10 @@ export class BitcoinKnots extends pulumi.ComponentResource {
                     debugExclude,
                     externalIp,
                     maxConnections,
+                    rpcUsers: this.args.rpcUsers,
+                    useRpcAuthFile: true,
                 }),
-                'rpc.conf': BitcoinConf.createRpc(this.args.rpcUsers),
+                'rpc.conf': BitcoinConf.createRpc(this.args.rpcUsers, true),
             },
         });
 

--- a/stacks/bitcoin/utils/bitcoin-conf.ts
+++ b/stacks/bitcoin/utils/bitcoin-conf.ts
@@ -2,9 +2,14 @@ import * as pulumi from '@pulumi/pulumi';
 
 import { RpcUser } from './rpc-user';
 
-function createRpc(rpcUsers: Record<string, RpcUser>): pulumi.Output<string> {
-    const authLines = Object.values(rpcUsers).map(
-        user => pulumi.interpolate`${user.rpcAuth}`,
+function createRpc(
+    rpcUsers: Record<string, RpcUser>,
+    useRpcAuthFile: boolean,
+): pulumi.Output<string> {
+    const authLines = Object.values(rpcUsers).map(user =>
+        useRpcAuthFile
+            ? pulumi.interpolate`${user.rpcAuth}`
+            : pulumi.interpolate`rpcauth=${user.rpcAuth}`,
     );
     return pulumi.all(authLines).apply(lines => lines.join('\n'));
 }
@@ -15,13 +20,17 @@ function create({
     debugExclude,
     externalIp,
     maxConnections,
+    rpcUsers,
+    useRpcAuthFile,
 }: {
     prune: number;
     debug?: boolean;
     debugExclude: string;
     externalIp?: string;
     maxConnections: number;
-}): string {
+    rpcUsers: Record<string, RpcUser>;
+    useRpcAuthFile: boolean;
+}): pulumi.Output<string> {
     const debugExcludeLines = debugExclude
         .split(',')
         .map(value => value.trim())
@@ -29,7 +38,11 @@ function create({
         .map(value => `debugexclude=${value}`)
         .join('\n');
 
-    return `
+    const rpcAuth = useRpcAuthFile
+        ? pulumi.output('rpcauthfile=/conf/rpc.conf')
+        : createRpc(rpcUsers, useRpcAuthFile);
+
+    return pulumi.interpolate`
 ${prune > 0 ? `prune=${prune.toString()}` : 'txindex=1'}
 ${externalIp ? `externalip=${externalIp}` : ''}
 ${debug ? 'debug=all' : ''}
@@ -43,7 +56,7 @@ printtoconsole=1
 rpcallowip=0.0.0.0/0
 rpcbind=0.0.0.0
 server=1
-rpcauthfile=/conf/rpc.conf
+${rpcAuth}
 `;
 }
 


### PR DESCRIPTION
## Summary

The shared Bitcoin conf template emitted `rpcauthfile=/conf/rpc.conf` for both node flavors. `rpcauthfile` exists only in Bitcoin Knots — Bitcoin Core's config parser treats unknown keys as fatal, so `bitcoind` exits at startup and the `bitcoin-core` component crash-loops (Knots is unaffected).

## Root cause

[Bitcoin Core PR #20407](https://github.com/bitcoin/bitcoin/pull/20407) (the `rpcauthfile` option) was closed unmerged; only Knots shipped it. Commit `60d89cb` switched both components to `rpcauthfile`, which worked for Knots but broke Core.

## Fix

Parameterize `BitcoinConf.create()` with `useRpcAuthFile`:
- **Bitcoin Core** (`useRpcAuthFile: false`) — inline `rpcauth=<user>:<salt>$<hash>` lines directly in `bitcoin.conf` (the pre-`60d89cb` format). The now-unused `rpc.conf` ConfigMap entry and the main container's `/conf` mount are removed; the init container stays (it copies `bitcoin.conf` into the data dir).
- **Bitcoin Knots** (`useRpcAuthFile: true`) — unchanged: `rpcauthfile=/conf/rpc.conf` with bare `<user>:<salt>$<hash>` lines, per the Knots `bitcoind` man page.

## Verification

- `npm run build` (library `tsc`) — clean
- `tsc --noEmit` and `eslint .` — clean
- Confirmed against the Knots man page that `rpcauthfile` lines must NOT carry the `rpcauth=` prefix, and against Core config parsing that inline `rpcauth=` is valid Core config.

