### PR TITLE
fix(iot): filter empty trustedProxies entries for home-assistant

### DIFF
--- a/stacks/iot/index.ts
+++ b/stacks/iot/index.ts
@@ -10,7 +10,8 @@ const homeAssistant = config.isEnabled('home-assistant')
     ? new HomeAssistant('home-assistant', {
           trustedProxies: (config.get('home-assistant', 'trustedProxies') ?? '')
               .split(',')
-              .map(s => s.trim()),
+              .map(s => s.trim())
+              .filter(Boolean),
           devices: config.getObject('home-assistant', 'devices') as
               | HomeAssistantDevice[]
               | undefined,


### PR DESCRIPTION
## Summary

With `home-assistant:trustedProxies` unset, the chart value became `trusted_proxies: ['']` (a single empty string) instead of falling back to sensible defaults.

## Root cause

`('' ?? '').split(',')` evaluates to `['']` — the nullish coalescing never fires and `split` on an empty string returns an array containing one empty string. An empty-string proxy entry is not a valid trusted proxy for Home Assistant.

## Fix

Append `.filter(Boolean)` after the trim so unset or empty config yields `[]`.

## Verification

- `tsc --noEmit` and `eslint .` — clean

