### PR TITLE
fix(scripts): match pods by name label in exec and open tailscale port as UDP

### DIFF
--- a/scripts/exec.sh
+++ b/scripts/exec.sh
@@ -5,20 +5,14 @@
 
 appName=$1
 namespace=${2:-$1}  # app name as namespace if not provided
-label=app.kubernetes.io/name
-
 if [ -z "$appName" ]; then
   echo "Error: Application name is required"
   echo "Usage: exec <app-name> [namespace]"
   exit 1
 fi
 
-if [[ "$appName" == "open-webui" ]]; then
-    label=app.kubernetes.io/component
-fi
-
 # Get the first pod name
-pod=$(kubectl get pods -l $label=$appName -n $namespace -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+pod=$(kubectl get pods -l app.kubernetes.io/name=$appName -n $namespace -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
 
 if [ -z "$pod" ]; then
   echo "Error: No pod found for app $appName in namespace $namespace"

--- a/scripts/firewall-fedora.sh
+++ b/scripts/firewall-fedora.sh
@@ -12,7 +12,7 @@ firewall-cmd --permanent --zone=$ZONE --add-source=$CLUSTER_CIDR
 firewall-cmd --permanent --zone=$ZONE --add-source=$SERVICE_CIDR
 firewall-cmd --permanent --zone=$ZONE --add-port=6443/tcp
 firewall-cmd --permanent --zone=$ZONE --add-port=10250/tcp
-firewall-cmd --permanent --zone=$ZONE --add-port=41641/tcp
+firewall-cmd --permanent --zone=$ZONE --add-port=41641/udp
 firewall-cmd --permanent --zone=$ZONE --add-interface=tailscale0
 
 firewall-cmd --reload


### PR DESCRIPTION
## Summary

Two one-line script fixes:

1. **`exec open-webui` always failed with "No pod found"** — `exec.sh` special-cased open-webui to select pods by `app.kubernetes.io/component=open-webui`, but those pods are labeled `component: default` (the fallback when a deployment has no explicit name, see `metadata.ts`). The default `app.kubernetes.io/name` label already matches open-webui pods, so the special case is removed entirely.
2. **Tailscale port opened as TCP** — `firewall-fedora.sh` had `--add-port=41641/tcp`, but tailscaled's WireGuard port 41641 is UDP. Changed to `--add-port=41641/udp`.

## Verification

- `bash -n` and shellcheck on both scripts — clean
- `exec.sh open-webui` now reaches the pod lookup via the name label (fails cleanly with the correct error when no pod exists, as expected on a dev machine)

