### PR TITLE
fix(scripts): fail loudly in mariadb-password and list-volumes on lookup errors

### DIFF
--- a/scripts/list-volumes.sh
+++ b/scripts/list-volumes.sh
@@ -20,7 +20,10 @@ EXCLUDE_APPS=(
 )
 
 # Get all config as JSON
-config=$(pulumi config -j 2>/dev/null)
+config=$(pulumi config -j) || {
+  echo "Error: Failed to read Pulumi config. Run this script from a stack directory (e.g. stacks/apps)."
+  exit 1
+}
 
 # Get enabled apps (excluding system components and hostpath apps)
 enabled_apps=$(echo "$config" | jq -r '

--- a/scripts/mariadb-password.sh
+++ b/scripts/mariadb-password.sh
@@ -22,10 +22,17 @@ fi
 
 # Read rootPassword from DB secret
 echo "Retrieving MariaDB root password from secret for app: $appName"
-rootPassword=$(kubectl get secret -n $appName $appName-db-secret -o jsonpath='{.data.rootPassword}' | base64 -d)
+secret=$(kubectl get secret -n "$appName" "$appName-db-secret" -o jsonpath='{.data.rootPassword}')
 
 if [ $? -ne 0 ]; then
     echo "Error: Failed to retrieve root password from secret"
+    exit 1
+fi
+
+rootPassword=$(echo "$secret" | base64 -d)
+
+if [ -z "$rootPassword" ]; then
+    echo "Error: Retrieved root password is empty"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Two operator-facing robustness fixes:

1. **`mariadb-password.sh` could write an empty password into Pulumi config** — it piped `kubectl get secret ... | base64 -d` and then checked `$?`, which reflects `base64`'s exit status (0 even on empty input). A missing secret/namespace/key was silently masked. kubectl now runs un-piped with its own status checked, plus a guard that refuses to continue with an empty password.
2. **`list-volumes.sh` died silently outside a stack directory** — `config=$(pulumi config -j 2>/dev/null)` swallowed stderr, and `set -euo pipefail` then killed the script with zero output. stderr is no longer swallowed and a clear "run from a stack directory" error is printed.

## Verification

- `bash -n` and shellcheck on both scripts — clean
- Failure paths exercised: `mariadb-password.sh nonexistent-app` now shows kubectl's error and stops; `list-volumes.sh` from a non-stack directory prints the new error message instead of exiting silently.

