### PR TITLE
docs: correct config keys and stack output paths across component docs

### DIFF
--- a/stacks/ai/components/invokeai/invokeai.md
+++ b/stacks/ai/components/invokeai/invokeai.md
@@ -15,7 +15,7 @@ Note: The community edition does not support user authentication so the images y
 Note: Unlike _automatic1111_ and _sdnext_, it doesn't integrate with WebUI.
 
 ```sh
-pulumi config set invokeai:enable true
+pulumi config set invokeai:enabled true
 
 # (Optional) override image for AMD GPU
 # pulumi config set invokeai:image ghcr.io/invoke-ai/invokeai:main-rocm

--- a/stacks/ai/components/kubeai/kubeai.md
+++ b/stacks/ai/components/kubeai/kubeai.md
@@ -29,7 +29,8 @@ pulumi up
 Prometheus monitoring and related Grafana dashboard for vLLM can be enabled with:
 
 ```sh
-pulumi set kubeai:enableMonitoring true
+pulumi config set prometheus:enabled true
+pulumi config set prometheus:enableComponentMonitoring true
 ```
 
 Note that Prometheus has to be installed first before changing that switch.

--- a/stacks/ai/components/ollama/ollama.md
+++ b/stacks/ai/components/ollama/ollama.md
@@ -30,11 +30,10 @@ pulumi config set ollama:version ""
 # Recommended when using AMD to allow GPU sharing (required to determine image tag)
 pulumi config set ollama:appVersion 0.13.1
 
-# Limit GPU access to specific devices in multi-GPU setups
-# (comma-separated device IDs, 0-indexed)
-pulumi config set ollama:HIP_VISIBLE_DEVICES "0"
-# or for NVIDIA
-pulumi config set ollama:CUDA_VISIBLE_DEVICES "0,1"
+# (Optional, AMD only) override GFX version for RDNA1/2 cards (e.g. 10.3.0)
+pulumi config set ollama:HSA_OVERRIDE_GFX_VERSION "10.3.0"
+# (Optional, AMD only) set ROCm compilation targets (e.g. gfx1030)
+pulumi config set ollama:HCC_AMDGPU_TARGETS "gfx1030"
 
 # Preload models at startup (comma-separated list)
 pulumi config set ollama:models "qwen2.5-coder:1.5b,gpt-oss:20b"
@@ -72,7 +71,7 @@ export OLLAMA_HOST=<endpoint>
 Get the new endpoint with:
 
 ```sh
-pulumi stack output --json | jq -r '.ai.endpoints.ollama'
+pulumi stack output --json | jq -r '.endpoints.ollama'
 ```
 
 You can also setup your tools to use OpenAPI-compatible endpoint by adding `/v1/` to the URL.

--- a/stacks/apps/components/nextcloud/nextcloud.md
+++ b/stacks/apps/components/nextcloud/nextcloud.md
@@ -31,8 +31,12 @@ pulumi config set nextcloud:enabled true
 pulumi config set nextcloud:hostname nextcloud
 # Set storage size (default: 20Gi)
 pulumi config set nextcloud:storageSize 50Gi
-# Set storage size for PostgreSQL database (default: 5Gi)
-pulumi config set nextcloud:storageSize 10Gi
+# Set storage size for MariaDB database (default: 5Gi)
+pulumi config set nextcloud:db/storageSize 10Gi
+# (Required) trusted proxy CIDRs, comma-separated
+pulumi config set nextcloud:trustedProxies '10.42.0.0/16,10.43.0.0/16'
+# (Required) group sync filter for Pocket ID group provisioning
+pulumi config set nextcloud:groupProvisioningWhitelist '^nextcloud-.*$'
 # (Required) admin password, also used to match restored backups
 KEY=$(openssl rand -base64 32)
 pulumi config set nextcloud:adminPassword "$KEY" --secret
@@ -54,6 +58,7 @@ Requires [Pocket ID](../../../../components/security/pocket/pocket.md) deployed 
 ```sh
 cd stacks/apps
 
+DISCOVERY_URL=$(pulumi --cwd ../.. stack output --json | jq -er '.security.oidcProviderUrl')
 NEXTCLOUD_URL=$(pulumi stack output --json | jq -er '.endpoints.nextcloud')
 ENDSESSION_ENDPOINT=$(curl -fsSL "$DISCOVERY_URL" | jq -er '.end_session_endpoint')
 
@@ -75,7 +80,7 @@ The helper creates or reuses the client and prints the required Pulumi configura
 pulumi config set nextcloud:auth pocket
 pulumi config set nextcloud:auth/clientId <client-id>
 pulumi config set nextcloud:auth/clientSecret <client-secret> --secret
-# Optional: override the default ^nextcloud-.*$ group sync filter.
+# Optional: override the group sync filter set in the basic configuration.
 # All users can still log in; only matching groups are synchronized.
 pulumi config set nextcloud:groupProvisioningWhitelist '^nextcloud-.*$'
 pulumi up

--- a/stacks/bitcoin/components/bitcoin-knots/bitcoin-knots.md
+++ b/stacks/bitcoin/components/bitcoin-knots/bitcoin-knots.md
@@ -22,7 +22,7 @@ pulumi config set bitcoin-knots:commandArgs "bitcoind -datadir=/data"
 # Set to external IP of your router. Port forwarding needs to be setup for port 8333
 pulumi config set bitcoin-knots:externalip <public-ip>
 # Increase number of peer connections (default 20)
-pulumi config set bitcoin-core:maxconnections 50
+pulumi config set bitcoin-knots:maxconnections 50
 # Note: Pruned nodes are incompatible with Electrs and Mempool
 pulumi config set bitcoin-knots:prune 1000  # Prune mode (MB), 0 for full node with txindex
 

--- a/stacks/bitcoin/components/mempool/mempool.md
+++ b/stacks/bitcoin/components/mempool/mempool.md
@@ -27,7 +27,8 @@ pulumi config set mempool:enabled true
 # Optional configuration
 pulumi config set mempool:backend/image mempool/backend:v3.2.1
 pulumi config set mempool:frontend/image mempool/frontend:v3.2.1
-pulumi config set mempool:hostname explorer # override hostname
+pulumi config set mempool:frontend/hostname explorer # public frontend hostname
+pulumi config set mempool:backend/hostname mempool-backend # cluster-internal backend hostname
 
 pulumi up
 

--- a/stacks/media/components/prowlarr/prowlarr.md
+++ b/stacks/media/components/prowlarr/prowlarr.md
@@ -26,9 +26,9 @@ After deployment, access Prowlarr at the endpoint URL and complete these steps i
 
 ```sh
 # Show cluster endpoints
-pulumi stack output --show-secrets --json | jq -r '.media.clusterUrls.prowlarr'
-pulumi stack output --show-secrets --json | jq -r '.media.clusterUrls.radarr'
-pulumi stack output --show-secrets --json | jq -r '.media.clusterUrls.sonarr'
+pulumi stack output --show-secrets --json | jq -r '.clusterUrls.prowlarr'
+pulumi stack output --show-secrets --json | jq -r '.clusterUrls.radarr'
+pulumi stack output --show-secrets --json | jq -r '.clusterUrls.sonarr'
 ```
 
 1. **Authentication** — on first access, complete the setup modal (or later via Settings → General → Security): set Authentication to Forms and create an admin user

--- a/stacks/media/components/seerr/seerr.md
+++ b/stacks/media/components/seerr/seerr.md
@@ -45,9 +45,9 @@ Get external URLs:
 
 ```sh
 # Show URLs
-pulumi stack output --show-secrets --json | jq -r '.media.endpoints.jellyfin'
-pulumi stack output --show-secrets --json | jq -r '.media.endpoints.radarr'
-pulumi stack output --show-secrets --json | jq -r '.media.endpoints.sonarr'
+pulumi stack output --show-secrets --json | jq -r '.endpoints.jellyfin'
+pulumi stack output --show-secrets --json | jq -r '.endpoints.radarr'
+pulumi stack output --show-secrets --json | jq -r '.endpoints.sonarr'
 ```
 
 ### 1. Jellyfin (required)

--- a/stacks/media/components/transmission/transmission.md
+++ b/stacks/media/components/transmission/transmission.md
@@ -29,10 +29,10 @@ pulumi up
 
 ```sh
 # Show cluster endpoint
-pulumi stack output --show-secrets --json | jq -r '.media.clusterUrls.transmission'
+pulumi stack output --show-secrets --json | jq -r '.clusterUrls.transmission'
 
 # Show browser URL
-pulumi stack output --show-secrets --json | jq -r '.media.endpoints.transmission'
+pulumi stack output --show-secrets --json | jq -r '.endpoints.transmission'
 ```
 
 Add Transmission as a download client at **Settings → Download Clients → Add → Transmission**:


### PR DESCRIPTION
## Summary

Corrects component docs that instructed wrong, dead, or stale configuration keys and stack-output paths (each verified against the code):

- **invokeai.md** — `invokeai:enable` → `invokeai:enabled` (the code reads `enabled` via `config.isEnabled`; following the doc deployed nothing)
- **bitcoin-knots.md** — `bitcoin-core:maxconnections` → `bitcoin-knots:maxconnections`
- **mempool.md** — dead key `mempool:hostname` → the real required keys `mempool:frontend/hostname` and `mempool:backend/hostname`
- **kubeai.md** — bogus `pulumi set kubeai:enableMonitoring true` → the real gate: `prometheus:enabled` + `prometheus:enableComponentMonitoring`
- **nextcloud.md** — duplicate `nextcloud:storageSize` (second line overwrote the first) → `nextcloud:db/storageSize`; "PostgreSQL" → MariaDB; documented the required `nextcloud:trustedProxies` and `nextcloud:groupProvisioningWhitelist` keys; fixed the OAuth snippet using `$DISCOVERY_URL` before it was defined
- **transmission.md, seerr.md, prowlarr.md, ollama.md** — stale `.media.*` / `.ai.*` jq prefixes on `pulumi stack output` (stacks export top-level `clusterUrls` / `endpoints`)
- **ollama.md** — removed `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` (never read by the code); documented the AMD keys that are actually read (`HSA_OVERRIDE_GFX_VERSION`, `HCC_AMDGPU_TARGETS`)

## Verification

Markdown-only — no tests needed per project convention. Every key/path cross-checked against the component source before editing.

